### PR TITLE
Cleanups

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -143,12 +143,6 @@ class %1(ClassName)(%2(object)):
 	'''
 	def __init__(self%4(, %5(arg))):
 		%6(super(%1, self).__init__())]]
-snip.try = [[
-try:
-	%0
-except %2(Exception) as %3(e):
-	%4(pass)%5(
-finally:
-    %6(pass))]]
+snip.try = "try:\n\t%0\nexcept %2(Exception) as %3(e):\n\t%4(pass)%5(\nfinally:\n\t%6(pass))"
 
 return M

--- a/init.lua
+++ b/init.lua
@@ -134,13 +134,13 @@ end
 local snip = snippets.python
 snip['.'] = 'self.'
 snip.__ = '__%1(init)__'
-snip.def = "def %1(name)(%2(arg)):\n\t%3('''%4\n\t'''\n\t)"
-snip.defs = "def %1(name)(self%2(, %3(arg))):\n\t%4('''%5\n\t'''\n\t)"
+snip.def = "def %1(name)(%2(arg)):\n\t%3('''%4'''\n\t)"
+snip.defs = "def %1(name)(self%2(, %3(arg))):\n\t%4('''%5'''\n\t)"
 snip.ifmain = "if __name__ == '__main__':\n\t%1(main())"
 snip.class = [[
 class %1(ClassName)(%2(object)):
-	'''%3(documentation)
-	'''
+	'''%3(documentation)'''
+
 	def __init__(self%4(, %5(arg))):
 		%6(super(%1, self).__init__())]]
 snip.try = "try:\n\t%0\nexcept %2(Exception) as %3(e):\n\t%4(pass)%5(\nfinally:\n\t%6(pass))"

--- a/init.lua
+++ b/init.lua
@@ -134,21 +134,28 @@ end
 local snip = snippets.python
 snip['.'] = 'self.'
 snip.__ = '__%1(init)__'
-snip.def = 'def %1(name)(%2(arg)):\n\t%3("""%4\n\t"""\n\t)'
-snip.defs = 'def %1(name)(self%2(, %3(arg))):\n\t%4("""%5\n\t"""\n\t)'
-snip.ifmain = 'if __name__ == "__main__":\n\t%1(main())'
+snip.def = [[def %1(name)(%2(arg)):
+    %3('''%4''')
+    ]]
+snip.defs = [[def %1(name)(self%2(, %3(arg))):
+    %4('''%5''')
+    ]]
+snip.ifmain = [[
+if __name__ == '__main__':
+    %1(main())
+]]
 snip.class = [[
-class %1(ClassName)(%2(object)):
-"""%3(documentation)
-"""
-def __init__(self%4(, %5(arg))):
-	%6(super(%1, self).__init__())]]
+class %1(ClassName)%2((%3(object))):
+    %4('''%5(documentation)''')
+    def __init__(self%6(, %7(arg))):
+        %8(super(%1, self).__init__())
+    ]]
 snip.try = [[
 try:
-	%0
-except %2(Exception), %3(e):
-	%4(pass)%5(
+    %0
+except %2(Exception) as %3(e):
+    %4(pass)%5(
 finally:
-	%6(pass))]]
+    %6(pass))]]
 
 return M


### PR DESCRIPTION
It's just that the documentation strings in many cases can be one line. It's better to let the programmer decide if (s)he wants multi-line than to force to delete the newline if there's only one line in the doc string (IMHO).